### PR TITLE
Truncate output

### DIFF
--- a/lib/board-view.js
+++ b/lib/board-view.js
@@ -20,6 +20,23 @@ export class BoardView {
         this.logs = message;
 
         this.cursorPosition = 0;
+        this.lineCount = 1;
+
+        this.truncateOutput = atom.config.get("language-circuitpython.truncateOutput");
+        atom.config.observe("language-circuitpython.truncateOutput", (newValue) => {
+            this.truncateOutput = newValue;
+        });
+
+        this.maxLines = atom.config.get("language-circuitpython.maxLines");
+        atom.config.observe("language-circuitpython.maxLines", (newValue) => {
+            this.maxLines = newValue;
+        });
+
+        this.outputBuffer = Buffer.alloc(0);
+        this.printingOutput = false;
+        this.floodCount = 0;
+        this.bufferFlooded = false;
+        this.resetFlooded = null;
 
         this.atomSerialPort = atomSerialPort;
 
@@ -34,69 +51,11 @@ export class BoardView {
             this.sp.pipe(this.parser);
 
             this.parser.on("data", (data) => {
-                // this.sendToPlotter(data.toString());
-                let shouldScroll = false;
-
-                // If 10 or less pixels from bottom then scroll with new output
-                if (this.logs.scrollHeight - this.logs.clientHeight <= this.logs.scrollTop + 10) {
-                    shouldScroll = true;
-                }
-
-                // Much of this code for communicating with the REPL over Serial
-                // was converted from the mu text editor.
-                // https://github.com/mu-editor/mu/blob/ee600ff16753194f33e39975662aba438a8f5608/mu/interface/panes.py#L243:L304
-                var i = 0;
-                while (i < data.length) {
-                    if (data[i] == 8) {  // \b
-                        this.moveCursorLeft(1);
-                    }else if (data[i] == 13) {  // \r
-                        var lastLineLength = this.logs.textContent.length - this.logs.textContent.lastIndexOf("\n") - 1;
-                        this.moveCursorLeft(lastLineLength);
-                    }else if (data.length > i + 1 && data[i] == 27 && data[i + 1] == 91) {
-                        // VT100 cursor detected: <Esc>[
-                        i+=2; // move index to after the [
-                        let re = /(?<count>[0-9]*)(;?[0-9]*)*(?<action>[ABCDKm])/;
-                        var m = re.exec(data.slice(i).toString());
-                        if (m != null) {
-                            // move to (almost) after control seq
-                            // (will ++ at end of loop)
-                            let mEnd = m.index + m[0].length;
-                            i += mEnd-1;
-
-                            var count = 1;
-                            if (m.groups.count == "") {
-                                count = 1;
-                            }else{
-                                count = parseInt(m.groups.count);
-                            }
-
-                            if (m.groups.action == "A") { // up
-                                // Not Used
-                            }else if (m.groups.action == "B") {  // down
-                                // Not Used
-                            }else if (m.groups.action == "C") {  // right
-                                // Not Used
-                            }else if (m.groups.action == "D") {  // left
-                                this.moveCursorLeft(count);
-                            }else if (m.groups.action == "K") { // delete things
-                                if (m.groups.count == "") {
-                                    this.deleteLine();
-                                }
-                            }
-                        }
-                    }else if (data[i] == 10) {  // \n
-                        this.moveCursorToEnd();
-                        this.insertChar(data[i]);
-                        this.removeExcessLines();
-                    }else{
-                        this.deleteChar();
-                        this.insertChar(data[i]);
-                    }
-                    i++;
-                }
-
-                if(shouldScroll) {
-                    this.logs.scrollTop = this.logs.scrollHeight;
+                this.outputBuffer = Buffer.concat([this.outputBuffer, data]);
+                this.floodCount++;
+                // If printingOutput is already scheduled to run, don't call again
+                if (!this.printingOutput) {
+                    this.printOutput();
                 }
             });
 
@@ -108,6 +67,7 @@ export class BoardView {
                     }
                     var currentText = this.logs.textContent;
                     this.logs.textContent = currentText + "\n--- Board Disconnected ---\nUse CTRL-R to attempt reconnect.\n\n";
+                    this.lineCount+=4;
                     this.moveCursorToEnd();
                     this.removeExcessLines();
 
@@ -176,6 +136,110 @@ export class BoardView {
         });
     }
 
+    printOutput() {
+        let shouldScroll = false;
+        this.printingOutput = true;
+        this.checkForFlooding();
+
+        // If 10 or less pixels from bottom then scroll with new output
+        if (this.logs.scrollHeight - this.logs.clientHeight <= this.logs.scrollTop + 10) {
+            shouldScroll = true;
+        }
+
+        // Much of this code for communicating with the REPL over Serial
+        // was converted from the mu text editor.
+        // https://github.com/mu-editor/mu/blob/ee600ff16753194f33e39975662aba438a8f5608/mu/interface/panes.py#L243:L304
+        var i = 0;
+        var data = this.outputBuffer;
+        // If the buffer is being flooded with too much data, truncate the buffer so the repl will still
+        // be responsive. This will help if there is a loop outputting text with no delay.
+        // This functionality can be turned on or off through the 'Truncate Output' setting.
+        if (this.truncateOutput && this.bufferFlooded && data.length > 2000) {
+            this.outputBuffer = this.outputBuffer.slice(-500);
+            data = this.outputBuffer;
+            var currentText = this.logs.textContent;
+            this.logs.textContent = currentText + "\n... (Output Truncated) ...\n";
+            this.lineCount+=2;
+            this.moveCursorToEnd();
+        }
+        var start = Date.now();
+        while (i < data.length) {
+            // If the buffer is flooded, only print out characters for the duration of the parser delay. This is done
+            // to avoid blocking for too long in this loop. By limiting the duration, new input from the parser
+            // won't be blocked and won't get too 'backed up'. This also allows for more data to be truncated, if
+            // necessary, once again avoiding the printing falling too far behind the microcontroller's output.
+            if (this.bufferFlooded && ((Date.now() - start) >= this.parser.delay)) {
+                break;
+            }
+
+            if (data[i] == 8) {  // \b
+                this.moveCursorLeft(1);
+            }else if (data[i] == 13) {  // \r
+                var lastLineLength = this.logs.textContent.length - this.logs.textContent.lastIndexOf("\n") - 1;
+                this.moveCursorToEnd();
+                this.moveCursorLeft(lastLineLength);
+            }else if (data.length > i + 1 && data[i] == 27 && data[i + 1] == 91) {
+                // VT100 cursor detected: <Esc>[
+                i+=2; // move index to after the [
+                let re = /(?<count>[0-9]*)(;?[0-9]*)*(?<action>[ABCDKm])/;
+                var m = re.exec(data.slice(i).toString());
+                if (m != null) {
+                    // move to (almost) after control seq
+                    // (will ++ at end of loop)
+                    let mEnd = m.index + m[0].length;
+                    i += mEnd-1;
+
+                    var count = 1;
+                    if (m.groups.count == "") {
+                        count = 1;
+                    }else{
+                        count = parseInt(m.groups.count);
+                    }
+
+                    if (m.groups.action == "A") { // up
+                        // Not Used
+                    }else if (m.groups.action == "B") {  // down
+                        // Not Used
+                    }else if (m.groups.action == "C") {  // right
+                        // Not Used
+                    }else if (m.groups.action == "D") {  // left
+                        this.moveCursorLeft(count);
+                    }else if (m.groups.action == "K") { // delete things
+                        if (m.groups.count == "") {
+                            this.deleteToEndOfLine();
+                        }
+                    }
+                }
+            }else if (data[i] == 10) {  // \n
+                this.moveCursorToEnd();
+                this.insertChar(data[i]);
+                this.lineCount++;
+                this.removeExcessLines();
+            }else{
+                this.deleteChar();
+                this.insertChar(data[i]);
+            }
+            i++;
+        }
+
+        if(shouldScroll) {
+            this.logs.scrollTop = this.logs.scrollHeight;
+        }
+        if (this.outputBuffer.length > i) {
+            // Buffer isn't empty, schedule another printOutput
+            setTimeout(this.printOutput.bind(this), 0);
+        }else{
+            this.printingOutput = false;
+        }
+        this.outputBuffer = this.outputBuffer.slice(i); // Update the buffer to whatever hasn't been printed
+
+        // If enough time passes, reset the flood count
+        this.resetFlooded = setTimeout(() => {
+            this.floodCount = 0;
+            this.resetFlooded = null;
+        }, 70);
+    }
+
     printableKeyPress(keyCode) {
         var valid =
         (keyCode > 47 && keyCode < 58)   || // number keys
@@ -223,17 +287,26 @@ export class BoardView {
         this.moveCursorTo(this.cursorPosition);
     }
 
-    deleteLine() {
+    deleteToEndOfLine() {
         while (this.logs.textLength > this.cursorPosition) {
             this.deleteChar();
         }
     }
 
     removeExcessLines() {
-        if (this.logs.textContent.split("\n").length > atom.config.get("language-circuitpython.maxLines")) {
-            this.logs.textContent = this.logs.textContent.split("\n").slice(atom.config.get("language-circuitpython.maxLines") - 40).join("\n");
+        if (this.lineCount > this.maxLines) {
+            var lines = this.logs.textContent.split("\n");
+            this.logs.textContent = lines.slice(-40).join("\n");
             this.moveCursorToEnd();
+            this.lineCount = 40;
         }
+    }
+
+    checkForFlooding() {
+        // Clear the resetFlooded scheduled function and check if we are flooded
+        clearTimeout(this.resetFlooded);
+        this.resetFlooded = null;
+        this.bufferFlooded = this.floodCount >= 5;
     }
 
     getTitle() {

--- a/lib/board-view.js
+++ b/lib/board-view.js
@@ -53,6 +53,7 @@ export class BoardView {
             this.parser.on("data", (data) => {
                 this.outputBuffer = Buffer.concat([this.outputBuffer, data]);
                 this.floodCount++;
+                this.checkForFlooding();
                 // If printingOutput is already scheduled to run, don't call again
                 if (!this.printingOutput) {
                     this.printOutput();
@@ -163,7 +164,7 @@ export class BoardView {
             this.moveCursorToEnd();
         }
         var start = Date.now();
-        while (i < data.length) {
+        while (i < data.length && ((Date.now() - start) < 1000)) {
             // If the buffer is flooded, only print out characters for the duration of the parser delay. This is done
             // to avoid blocking for too long in this loop. By limiting the duration, new input from the parser
             // won't be blocked and won't get too 'backed up'. This also allows for more data to be truncated, if
@@ -228,6 +229,7 @@ export class BoardView {
         if (this.outputBuffer.length > i) {
             // Buffer isn't empty, schedule another printOutput
             setTimeout(this.printOutput.bind(this), 0);
+            this.floodCount++;
         }else{
             this.printingOutput = false;
         }

--- a/lib/language-circuitpython.js
+++ b/lib/language-circuitpython.js
@@ -26,6 +26,11 @@ export default {
             default: 100,
             minimum: 50,
             description: "Maximum lines to display in the serial output console"
+        },
+        truncateOutput: {
+            type: "boolean",
+            default: true,
+            description: "Truncate the output from the microcontroller when it is very long. This can help improve responsiveness."
         }
     },
     activate() {

--- a/lib/parser-delay.js
+++ b/lib/parser-delay.js
@@ -25,12 +25,10 @@ export class DelayParser extends Transform {
     }
 
     _transform(chunk, encoding, callback) {
-        if (this.timeoutCall != null) {
-            clearTimeout(this.timeoutCall);
-            this.timeoutCall = null;
-        }
         this.buffer = Buffer.concat([this.buffer, chunk]);
-        this.delayedPush();
+        if (this.timeoutCall == null) {
+            this.delayedPush();
+        }
         callback();
     }
 


### PR DESCRIPTION
When text is output too quickly from the microcontroller we currently appear as if we are frozen and not responsive. With these changes the output will update as it is received from the microcontroller. These changes also allow for the option to truncate the text if it starts to get too backed up. An example of when this might happen is while in a loop with no delay. The CP docs advise to always put in a delay of some amount while doing this....but in the event someone forgets it would be nice if the serial connection remains responsive!