### PR TITLE
Add tab completion

### DIFF
--- a/lib/board-view.js
+++ b/lib/board-view.js
@@ -13,7 +13,8 @@ var keydownOutput = {
     "ArrowRight" : "\x1B[C",
     "ArrowDown" : "\x1B[B",
     "Home" : "\x1B[H",
-    "End" : "\x1B[F"
+    "End" : "\x1B[F",
+    "Tab" : "\t"
 };
 
 export class BoardView {
@@ -109,6 +110,10 @@ export class BoardView {
                 return;
 
             var shouldScroll = false;
+
+            if (event.key === "Tab") {
+              event.preventDefault();
+            }
 
             if (event.key in keydownOutput) {
                 this.sp.write(keydownOutput[event.key]);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "language-circuitpython:toggle-plotter"
     ]
   },
-  "repository": "https://github.com/jos-b/language-circuitpython",
+  "repository": "https://github.com/jb3/language-circuitpython",
   "license": "MIT",
   "engines": {
     "atom": ">=1.0.0 <2.0.0"


### PR DESCRIPTION
Adds support for tab completion in the REPL by preventing the default tab event and handling the key like we do the arrow keys.

<img width="839" alt="Screenshot 2020-10-20 at 00 52 38" src="https://user-images.githubusercontent.com/20439493/96523816-8f036900-126e-11eb-9714-be254b3a99a0.png">
